### PR TITLE
fixing email routes test

### DIFF
--- a/src/api/auth/auth.router.spec.js
+++ b/src/api/auth/auth.router.spec.js
@@ -71,7 +71,10 @@ describe('Auth Integration Tests', () => {
 
       // Confirm the email
       await request(app)
-        .get(`/confirm/${registerBody.body.confirmEmailToken}`)
+        .get('/confirm')
+        .query({
+          token: registerBody.body.confirmEmailToken,
+        })
         .expect(302)
 
       // Login


### PR DESCRIPTION
I had changed the way the confirm email section of the API handles receiving data from user. That's why our tests were failing.