### PR TITLE
Fixed Responsiveness of the headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   },
   "dependencies": {
     "@firebase/app-types": "0.3.2",
-    "@material-ui/core": "3.3.0",
-    "@material-ui/icons": "3.0.1",
+    "@material-ui/core": "3.9.2",
+    "@material-ui/icons": "3.0.2",
+    "@material-ui/styles": "3.0.0-alpha.10",
     "axios": "~0.18.0",
     "bcryptjs": "~2.0",
     "body-parser": "~1.18.3",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-react": "7.11.1",
     "firebase-functions-test": "0.1.5",
     "husky": "1.3.1",
+    "jss": "9.8.7",
     "lint-staged": "8.1.4",
     "nodemon": "^1.18.3",
     "prettier": "1.16.4",

--- a/scripts/env.py
+++ b/scripts/env.py
@@ -10,6 +10,7 @@ print('For email username and password, I recommend going to etherial.mail')
 SERVICES = {
     'environment': [
         'env',
+        'maintainance',
         'session_secret'
     ],
     'email': [
@@ -18,7 +19,7 @@ SERVICES = {
     ],
     'connections': [
         'protocol',
-        'h',
+        'host',
         'db'
     ]
 }
@@ -33,7 +34,7 @@ def get_env(env_vars, service):
             system('firebase functions:config:set {}.{}={}'.format(service, env, val))
 
     print('Done')
-    choice = input('Would you like to save th settings for local development? [Y/n] ')
+    choice = input('Would you like to save the settings for local development? [Y/n] ')
 
     if choice.lower() != 'y':
         exit()
@@ -55,7 +56,7 @@ def pick_environment():
         print('Setting up {} environment'.format(choice))
         system('firebase functions:config:set environment.env={}'.format(choice))
 
-def cho_service():
+def choose_service():
     '''Asks the user what service they want to configure'''
     svc_choice = input('What service would you like to configure? [environment/email/connections] ')
     if svc_choice == '':
@@ -70,4 +71,4 @@ def cho_service():
 
 if __name__ == '__main__':
     pick_environment()
-    cho_service()
+    choose_service()

--- a/src/client/components/PageHeader.jsx
+++ b/src/client/components/PageHeader.jsx
@@ -1,51 +1,74 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-// import 'typeface-roboto';
-import { Typography } from '@material-ui/core';
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useTheme } from '@material-ui/styles'
+import useWindowSize from 'hooks/useWindowSize'
 
-const styles = {
-  PageHeader: {
-    display: 'flex',
-    color: 'white',
-    width: '100%',
-    minHeight: '980px',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'column',
-    textAlign: 'center',
-  },
-  title: {
-    fontWeight: 'bold',
-  },
-  info: {
-    display: 'flex',
-    width: '61%', // '65.5%',
-    margin: 'auto',
-    textAlign: 'center',
-    justifyContent: 'center',
-    wordWrap: 'break-word',
-  },
-};
+const getStyles = (theme, windowWidth, windowHeight, color) => {
+  let titleSize = theme.typography.h2
+  let infoSize = theme.typography.h6
+  let infoWidth = '61%'
+
+  if (windowWidth < theme.breakpoints.values.sm) {
+    titleSize = theme.typography.h4
+    infoSize = theme.typography.body2
+    infoWidth = '80%'
+  }
+
+  const curr = {
+    PageHeader: {
+      display: 'flex',
+      color: 'white',
+      width: '100%',
+      minHeight: windowHeight - 64,
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'column',
+      textAlign: 'center',
+      backgroundColor: color,
+    },
+    title: {
+      ...titleSize,
+      fontWeight: 'bold',
+    },
+    info: {
+      ...infoSize,
+      display: 'flex',
+      width: infoWidth,
+      margin: 'auto',
+      textAlign: 'center',
+      justifyContent: 'center',
+      wordWrap: 'break-word',
+    },
+  }
+
+  return curr
+}
 
 const PageHeader = ({
-  classes = {}, title, info, color,
-}) => (
-  <div style={{ backgroundColor: color }} className={classes.PageHeader}>
-    <div><Typography variant='h2' className={classes.title}>{title}</Typography></div>
-    <div><Typography variant='h4' className={classes.info}>{info}</Typography></div>
-  </div>
-)
+  title, info, color,
+}) => {
+  const theme = useTheme()
+  const { width, height } = useWindowSize()
+
+  const classes = getStyles(theme, width, height, color)
+
+  return (
+    <div style={classes.PageHeader}>
+      <div><div style={classes.title}>{title}</div></div>
+      <div><div style={classes.info}>{info}</div></div>
+    </div>
+  )
+}
 
 PageHeader.propTypes = {
   color: PropTypes.string,
   classes: PropTypes.shape({}),
   title: PropTypes.string,
   info: PropTypes.string,
-};
+}
 
 PageHeader.defaultProps = {
   color: '#253F51',
 }
 
-export default withStyles(styles)(PageHeader);
+export default PageHeader

--- a/src/client/components/PageHeader.jsx
+++ b/src/client/components/PageHeader.jsx
@@ -62,7 +62,6 @@ const PageHeader = ({
 
 PageHeader.propTypes = {
   color: PropTypes.string,
-  classes: PropTypes.shape({}),
   title: PropTypes.string,
   info: PropTypes.string,
 }

--- a/src/client/components/PageHeader.jsx
+++ b/src/client/components/PageHeader.jsx
@@ -2,47 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { useTheme } from '@material-ui/styles'
 import useWindowSize from 'hooks/useWindowSize'
-
-const getStyles = (theme, windowWidth, windowHeight, color) => {
-  let titleSize = theme.typography.h2
-  let infoSize = theme.typography.h6
-  let infoWidth = '61%'
-
-  if (windowWidth < theme.breakpoints.values.sm) {
-    titleSize = theme.typography.h4
-    infoSize = theme.typography.body2
-    infoWidth = '80%'
-  }
-
-  const curr = {
-    PageHeader: {
-      display: 'flex',
-      color: 'white',
-      width: '100%',
-      minHeight: windowHeight - 64,
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexDirection: 'column',
-      textAlign: 'center',
-      backgroundColor: color,
-    },
-    title: {
-      ...titleSize,
-      fontWeight: 'bold',
-    },
-    info: {
-      ...infoSize,
-      display: 'flex',
-      width: infoWidth,
-      margin: 'auto',
-      textAlign: 'center',
-      justifyContent: 'center',
-      wordWrap: 'break-word',
-    },
-  }
-
-  return curr
-}
+import createStyles from './PageHeader.styles'
 
 const PageHeader = ({
   title, info, color,
@@ -50,7 +10,7 @@ const PageHeader = ({
   const theme = useTheme()
   const { width, height } = useWindowSize()
 
-  const classes = getStyles(theme, width, height, color)
+  const classes = createStyles(theme, width, height, color)
 
   return (
     <div style={classes.PageHeader}>

--- a/src/client/components/PageHeader.styles.js
+++ b/src/client/components/PageHeader.styles.js
@@ -1,0 +1,40 @@
+export default function getStyles(theme, windowWidth, windowHeight, color) {
+  let titleSize = theme.typography.h2
+  let infoSize = theme.typography.h6
+  let infoWidth = '61%'
+
+  if (windowWidth < theme.breakpoints.values.sm) {
+    titleSize = theme.typography.h4
+    infoSize = theme.typography.body2
+    infoWidth = '80%'
+  }
+
+  const curr = {
+    PageHeader: {
+      display: 'flex',
+      color: 'white',
+      width: '100%',
+      minHeight: windowHeight - 64,
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'column',
+      textAlign: 'center',
+      backgroundColor: color,
+    },
+    title: {
+      ...titleSize,
+      fontWeight: 'bold',
+    },
+    info: {
+      ...infoSize,
+      display: 'flex',
+      width: infoWidth,
+      margin: 'auto',
+      textAlign: 'center',
+      justifyContent: 'center',
+      wordWrap: 'break-word',
+    },
+  }
+
+  return curr
+}

--- a/src/client/containers/MaintainanceContainer.jsx
+++ b/src/client/containers/MaintainanceContainer.jsx
@@ -24,11 +24,10 @@ function MaintainanceContainer({ history }) {
   if (firebase.apps.length === 0) firebase.initializeApp(config)
 
   if (err) {
-    console.error(err)
     return <MaintenanceScreen />
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV !== 'production') {
     // Changes this is you want to see the MaintenanceScreen
     return <Main history={history} />
   }

--- a/src/client/hooks/useEnvironment.js
+++ b/src/client/hooks/useEnvironment.js
@@ -24,7 +24,7 @@ export default function useEnvironment(connectionString) {
 
   useEffect(() => {
     async function fetchEnv() {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV === 'development') {
         setEnv(devEnv)
         setErr(null)
       } else {

--- a/src/client/hooks/useEnvironment.js
+++ b/src/client/hooks/useEnvironment.js
@@ -1,21 +1,14 @@
 import { useState, useEffect } from 'react'
 import axios from 'axios'
 
+const devEnv = {
+  env: 'dev',
+  maintainance: false,
+  session_secret: 'Whatever',
+}
+
 /**
  * Calls the environment provider to get all of the secrets from the API
- *
- * Firebase Secrets Provided
- *
- * - auth_provider_x509_cert_url
- * - auth_uri
- * - client_x509_cert_url
- * - private_key
- * - private_key_id
- * - project_id
- * - token_uri
- * - client_email
- * - client_id
- * - type
  *
  * Other Secrets
  *
@@ -31,13 +24,18 @@ export default function useEnvironment(connectionString) {
 
   useEffect(() => {
     async function fetchEnv() {
-      try {
-        const { data } = await axios.get(`${connectionString}/environment`)
-        const environment = data
-        setEnv(environment)
-      } catch (error) {
-        console.error(error)
-        setErr(error)
+      if (process.env.NODE_ENV !== 'production') {
+        setEnv(devEnv)
+        setErr(null)
+      } else {
+        try {
+          const { data } = await axios.get(`${connectionString}/environment`)
+          const environment = data
+          setEnv(environment)
+        } catch (error) {
+          console.error(error)
+          setErr(error)
+        }
       }
     }
 

--- a/src/client/hooks/useWindowSize.js
+++ b/src/client/hooks/useWindowSize.js
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react'
+
+export default function useWindowSize() {
+  const [width, setWidth] = useState(window.innerWidth)
+  const [height, setHeight] = useState(window.innerHeight)
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth)
+      setHeight(window.innerHeight)
+    }
+    window.addEventListener('resize', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  })
+
+  return { width, height }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import * as axios from 'axios'
 
 import { AppContainer, setConfig } from 'react-hot-loader'
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
+import { ThemeProvider } from '@material-ui/styles'
 import { red, black } from '@material-ui/core/colors'
 import { Provider } from 'react-redux'
 import { connectRouter, routerMiddleware } from 'connected-react-router'
@@ -57,9 +58,11 @@ function render() {
     <AppContainer>
       <Provider store={store}>
         <MuiThemeProvider theme={theme}>
-          <ConnectionStringProvider>
-            <MaintainanceContainer history={history} />
-          </ConnectionStringProvider>
+          <ThemeProvider theme={theme}>
+            <ConnectionStringProvider>
+              <MaintainanceContainer history={history} />
+            </ConnectionStringProvider>
+          </ThemeProvider>
         </MuiThemeProvider>
       </Provider>
     </AppContainer>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,19 +25,19 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
-  integrity sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==
-  dependencies:
-    regenerator-runtime "^0.12.0"
-
 "@babel/runtime@7.2.0", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
   integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
   dependencies:
     regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.2.0":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
+  integrity sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==
+  dependencies:
+    regenerator-runtime "^0.13.2"
 
 "@babel/runtime@^7.3.1":
   version "7.3.1"
@@ -63,6 +63,11 @@
   dependencies:
     debug "^3.1.0"
     lodash.once "^4.1.1"
+
+"@emotion/hash@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
+  integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==
 
 "@firebase/app-types@0.3.2":
   version "0.3.2"
@@ -330,30 +335,31 @@
     log-update "^2.3.0"
     strip-ansi "^3.0.1"
 
-"@material-ui/core@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.3.0.tgz#f30838db346faa54f3a23dd795ebaf043144e331"
-  integrity sha512-h340FXiJyAEQ1+xnOBaqLib9f6M82DEn0CicMVRekwTtPhFR9dDYdJT30WDPczS2piNiQ9kuFfFcAE9UTbwcXQ==
+"@material-ui/core@3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.9.2.tgz#41ed1a470e981d199829eb5d9317a671c66a6f7d"
+  integrity sha512-aukR3mSH3g115St2OnqoeMRtmxzxxx+Mch7pFKRV3Tz3URExBlZwOolimjxKZpG4LGec8HlhREawafLsDzjVWQ==
   dependencies:
-    "@babel/runtime" "7.1.2"
+    "@babel/runtime" "^7.2.0"
+    "@material-ui/system" "^3.0.0-alpha.0"
+    "@material-ui/utils" "^3.0.0-alpha.2"
     "@types/jss" "^9.5.6"
     "@types/react-transition-group" "^2.0.8"
     brcast "^3.0.1"
     classnames "^2.2.5"
     csstype "^2.5.2"
     debounce "^1.1.0"
-    deepmerge "^2.0.1"
+    deepmerge "^3.0.0"
     dom-helpers "^3.2.1"
-    hoist-non-react-statics "^2.5.0"
+    hoist-non-react-statics "^3.2.1"
     is-plain-object "^2.0.4"
-    jss "^9.3.3"
+    jss "^9.8.7"
     jss-camel-case "^6.0.0"
     jss-default-unit "^8.0.2"
     jss-global "^3.0.0"
     jss-nested "^6.0.1"
     jss-props-sort "^6.0.0"
     jss-vendor-prefixer "^7.0.0"
-    keycode "^2.1.9"
     normalize-scroll-left "^0.1.2"
     popper.js "^1.14.1"
     prop-types "^15.6.0"
@@ -362,13 +368,54 @@
     recompose "0.28.0 - 0.30.0"
     warning "^4.0.1"
 
-"@material-ui/icons@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.1.tgz#671fb3d04dcaf9351dbbd2bf82ae2ae72e3d93cd"
-  integrity sha512-1kNcxYiIT1x8iDPEAlgmKrfRTIV8UyK6fLVcZ9kMHIKGWft9I451V5mvSrbCjbf7MX1TbLWzZjph0aVCRf9MqQ==
+"@material-ui/icons@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.2.tgz#d67a6dd1ec8312d3a88ec97944a63daeef24fe10"
+  integrity sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==
   dependencies:
-    "@babel/runtime" "7.0.0"
-    recompose "^0.29.0"
+    "@babel/runtime" "^7.2.0"
+    recompose "0.28.0 - 0.30.0"
+
+"@material-ui/styles@3.0.0-alpha.10":
+  version "3.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-3.0.0-alpha.10.tgz#4c28a6d6dacb1fb71aff4642f92b63232a3f298d"
+  integrity sha512-qJ5eiupBPRCNlMCDZ2G5h8auBtBtm8uT/oCUAJ/FqhO5oC7POLmmvDN1Cq1cgAmqQnaL6uN5mAM1Gc90GpKr9A==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    "@emotion/hash" "^0.7.1"
+    "@material-ui/utils" "^3.0.0-alpha.2"
+    classnames "^2.2.5"
+    deepmerge "^3.0.0"
+    hoist-non-react-statics "^3.2.1"
+    jss "^10.0.0-alpha.7"
+    jss-plugin-camel-case "^10.0.0-alpha.7"
+    jss-plugin-default-unit "^10.0.0-alpha.7"
+    jss-plugin-global "^10.0.0-alpha.7"
+    jss-plugin-nested "^10.0.0-alpha.7"
+    jss-plugin-props-sort "^10.0.0-alpha.7"
+    jss-plugin-rule-value-function "^10.0.0-alpha.7"
+    jss-plugin-vendor-prefixer "^10.0.0-alpha.7"
+    prop-types "^15.6.0"
+    warning "^4.0.1"
+
+"@material-ui/system@^3.0.0-alpha.0":
+  version "3.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-3.0.0-alpha.2.tgz#096e80c8bb0f70aea435b9e38ea7749ee77b4e46"
+  integrity sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    deepmerge "^3.0.0"
+    prop-types "^15.6.0"
+    warning "^4.0.1"
+
+"@material-ui/utils@^3.0.0-alpha.2":
+  version "3.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-3.0.0-alpha.3.tgz#836c62ea46f5ffc6f0b5ea05ab814704a86908b1"
+  integrity sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    prop-types "^15.6.0"
+    react-is "^16.6.3"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -3322,6 +3369,14 @@ css-vendor@^0.3.8:
   dependencies:
     is-in-browser "^1.0.2"
 
+css-vendor@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-1.2.1.tgz#21b914913d3a68bab2708090dab2e61db7c9eaec"
+  integrity sha512-ZpwiWxn5jWNJ7NF3DAb/Dc/+c2lRu+fnovej/adCv3VJsULJSjdXEpUwRcq4fnpAAh98Hi7b0GDnlyoNFcdv1g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    is-in-browser "^1.0.2"
+
 css-what@2.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
@@ -3547,10 +3602,10 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^2.0.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+deepmerge@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
+  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -5879,6 +5934,13 @@ hoist-non-react-statics@^3.0.0:
   dependencies:
     react-is "^16.3.2"
 
+hoist-non-react-statics@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -7296,6 +7358,58 @@ jss-nested@^6.0.1:
   dependencies:
     warning "^3.0.0"
 
+jss-plugin-camel-case@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.7.tgz#7dcbd9acb6682f3102cb2d3356b4fd9642d93f17"
+  integrity sha512-Bwrav1ZB0XywdJW6TaEuFhKe1ZpZvUlESh3jsFOvebA9aFTYNCkmHMEqjA5+u9VMxksl3u77nnZHtukpxkzrBA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    hyphenate-style-name "^1.0.2"
+
+jss-plugin-default-unit@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.7.tgz#f6dd0a03d545e7bf243c062bae3a832ac8c5ff6d"
+  integrity sha512-auuJUbQaWMxoHOVFPrfZNZpZm9ab8PZeDyvey8nMt2lbokkmZ53UyAnM/1kNsg5BdAXTItcLDxDB3I4gwNU84g==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+jss-plugin-global@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.7.tgz#38ca390802b62da490afbaafc581552a81977729"
+  integrity sha512-OWeoW4szLDgRUKviST+xfilqa8O5uXJCW+O3YonheCRTRJg6rRzlE/b5pfYPoU9UtwvY9n7JvwBX5r3c1lMsEQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+jss-plugin-nested@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.7.tgz#03a89c8f7c1d570a3d5f16dae3e61f7f2edb0316"
+  integrity sha512-wsRzuIZXAc6WMjc61mREW9cUrDxgSI7dK/fx5c7a06IDUfSn+83NJ30J/RB4oBnbQW9SijV/muujz7IJqpn9Gw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.7.tgz#46f1809fcae0acc048d0047aa54a4b9b6973597d"
+  integrity sha512-KXOCaHUk1+KXqE0z3q66/w1fDoy+VsZvI77gLxOqTsTrvIKFLX0jarwXogW3CDlaPQQFTZ6JykJJXtPRTBlstA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+jss-plugin-rule-value-function@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.7.tgz#63df1078ac361dda67996e25291d90f7226ae59a"
+  integrity sha512-ett83hvIM69/LknmrWndrrdiDlfLfP+rneU5qP7gTOWJ7g1P9GuEL1Tc4CWdZUWBX+T58tgIBP0V1pzWCkP0QA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+jss-plugin-vendor-prefixer@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.7.tgz#caa34eb0bc39f0c98f425e174fc220d1f1a8760a"
+  integrity sha512-YbIVgqq+dLimOBOEYggho1Iuc0roz4PJSZYyaok9n8JnXVIqPnxYJbr8+bMbvzJ5CL3eeJij/e7L2IPCceRKrA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    css-vendor "^1.1.0"
+
 jss-props-sort@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
@@ -7308,7 +7422,16 @@ jss-vendor-prefixer@^7.0.0:
   dependencies:
     css-vendor "^0.3.8"
 
-jss@^9.3.3:
+jss@^10.0.0-alpha.7:
+  version "10.0.0-alpha.14"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.0.0-alpha.14.tgz#88ccf9038ffb358ae787173ac678c754d418e67c"
+  integrity sha512-2GDuLa4rq6+HnCtrNwEYE+fS+ea4kTfSNcsOOe9FvGunbUmB1r+XJ4IEjGDke4fHWHB6trAm5vp0yJP6iT7VwQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
+
+jss@^9.8.7:
   version "9.8.7"
   resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
   integrity sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==
@@ -7360,11 +7483,6 @@ kareem@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.2.1.tgz#9950809415aa3cde62ab43b4f7b919d99816e015"
   integrity sha512-xpDFy8OxkFM+vK6pXy6JmH92ibeEFUuDWzas5M9L7MzVmHW3jzwAHxodCPV/BYkf4A31bVDLyonrMfp9RXb/oA==
-
-keycode@^2.1.9:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
-  integrity sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=
 
 killable@^1.0.0:
   version "1.0.1"
@@ -10034,6 +10152,11 @@ react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
+react-is@^16.6.3:
+  version "16.8.5"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
+  integrity sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -10292,18 +10415,6 @@ readdirp@^2.0.0:
     react-lifecycles-compat "^3.0.2"
     symbol-observable "^1.0.4"
 
-recompose@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.29.0.tgz#f1a4e20d5f24d6ef1440f83924e821de0b1bccef"
-  integrity sha512-J/qLXNU4W+AeHCDR70ajW8eMd1uroqZaECTj6qqDLPMILz3y0EzpYlvrnxKB9DnqcngWrtGwjXY9JeXaW9kS1A==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    react-lifecycles-compat "^3.0.2"
-    symbol-observable "^1.0.4"
-
 recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
@@ -10372,6 +10483,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -11738,6 +11854,11 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-warning@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
+  integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
 
 tmp@0.0.31:
   version "0.0.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7422,6 +7422,15 @@ jss-vendor-prefixer@^7.0.0:
   dependencies:
     css-vendor "^0.3.8"
 
+jss@9.8.7, jss@^9.8.7:
+  version "9.8.7"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
+  integrity sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==
+  dependencies:
+    is-in-browser "^1.1.3"
+    symbol-observable "^1.1.0"
+    warning "^3.0.0"
+
 jss@^10.0.0-alpha.7:
   version "10.0.0-alpha.14"
   resolved "https://registry.yarnpkg.com/jss/-/jss-10.0.0-alpha.14.tgz#88ccf9038ffb358ae787173ac678c754d418e67c"
@@ -7430,15 +7439,6 @@ jss@^10.0.0-alpha.7:
     "@babel/runtime" "^7.3.1"
     is-in-browser "^1.1.3"
     tiny-warning "^1.0.2"
-
-jss@^9.8.7:
-  version "9.8.7"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
-  integrity sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==
-  dependencies:
-    is-in-browser "^1.1.3"
-    symbol-observable "^1.1.0"
-    warning "^3.0.0"
 
 jsx-ast-utils@^1.4.0:
   version "1.4.1"


### PR DESCRIPTION
Hey fun fact, we have a `useTheme()` hook in Material UI now. No more HOC :)

It returns the theme object. Just make sure to do
```jsx
import { useTheme } from '@material-ui/styles'
```
and now
```jsx
import { useTheme } from '@material-ui/core/styles'
```

Also, you need to make sure that you use the `style` prop instead of the `className` prop since we no longer get classes as props

## Changes
I upgraded to the latest material-ui/{core,styles,icons} minor versions. Nothing broke as it is a minor change. You need to reinstall node_modules.

Header now responds to the height and width of the viewport. Just use the useWindowSize hook that I made.

```jsx
import useWindowSize from 'hooks/useWindowSize'
```

#### Extras
I fixed a typo and saw that I needed the maintenance environment variable. So to fix this, i just created a devEnv object that gets passed during development. In production/staging we will actually fetch the env from the api

Also, we can **officially develop without an API** in terms of design. I was not running the API at all while developing this branch. I'm quite excited